### PR TITLE
Change sticky header position fixed to absolute and set its top position relevant to vertical scroll bar

### DIFF
--- a/dist/angular-sticky-table-header.js
+++ b/dist/angular-sticky-table-header.js
@@ -76,7 +76,6 @@ angular.module('turn/stickyTableHeader', ['watchDom']).value('stickyTableHeaderO
           }),
           setCloneGutter: ifClone(function () {
             scope.clone.css({
-              left: scope.offset.left,
               width: scope.offset.width
             });
           }),
@@ -109,7 +108,7 @@ angular.module('turn/stickyTableHeader', ['watchDom']).value('stickyTableHeaderO
             } else if (scope.stuck && scrollY < scope.offset.top) {
               scope.setStuck(false);
             }
-            scope.clone.css('left', scope.offset.left - scrollX);
+            scope.clone.css('top', ($window.pageYOffset || 0) - scope.offset.top);
           }),
           observeTr: function () {
             scope.mutationObserver = watchDom.$watch(scope.tr, _.throttle(scope.resetClone, options.observeHeaderInterval), { subtree: true });

--- a/src/angular-sticky-table-header.js
+++ b/src/angular-sticky-table-header.js
@@ -95,7 +95,6 @@ angular
 				setCloneGutter: ifClone(function () {
 
 					scope.clone.css({
-						left: scope.offset.left,
 						width: scope.offset.width
 					});
 
@@ -146,7 +145,7 @@ angular
 						scope.setStuck(false);
 					}
 
-					scope.clone.css('left', scope.offset.left - scrollX);
+					scope.clone.css('top', ($window.pageYOffset || 0) - scope.offset.top);
 
 				}),
 

--- a/src/angular-sticky-table-header.scss
+++ b/src/angular-sticky-table-header.scss
@@ -3,8 +3,8 @@
 
 	.sticky-clone {
 		display: table;
-		position: fixed;
-			top: 0;
+		position: absolute;
+		left: 0;
 		transform: translate3d(-100000px, 0, 0);
 		z-index: 1000;
 

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -185,12 +185,11 @@ describe 'angular-sticky-table-header', ->
 
 	describe '#setCloneGutter', ->
 
-		it 'should set the <th> clone\'s left and width CSS equal to scope.offset', ->
+		it 'should set the <th> clone\'s width CSS equal to scope.offset', ->
 
 			@scope.clone =
 				css: ->
 			@scope.offset =
-				left: 1
 				width: 2
 
 			spyOn @scope.clone, 'css'
@@ -436,7 +435,7 @@ describe 'angular-sticky-table-header', ->
 			.not.toHaveBeenCalled
 
 
-		it 'should set left', ->
+		it 'should not set left', ->
 
 			@scope.clone = css: ->
 			spyOn @scope.clone, 'css'
@@ -444,8 +443,17 @@ describe 'angular-sticky-table-header', ->
 			do @scope.checkScroll
 
 			expect @scope.clone.css
-			.toHaveBeenCalledWith 'left', jasmine.any(Number)
+			.not.toHaveBeenCalledWith 'left', jasmine.any(Number)
 
+		it 'should set top', ->
+
+			@scope.clone = css: ->
+			spyOn @scope.clone, 'css'
+
+			do @scope.checkScroll
+
+			expect @scope.clone.css
+			.toHaveBeenCalledWith 'top', jasmine.any(Number)
 
 
 	describe '#rowsChanged', ->

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -435,16 +435,6 @@ describe 'angular-sticky-table-header', ->
 			.not.toHaveBeenCalled
 
 
-		it 'should not set left', ->
-
-			@scope.clone = css: ->
-			spyOn @scope.clone, 'css'
-
-			do @scope.checkScroll
-
-			expect @scope.clone.css
-			.not.toHaveBeenCalledWith 'left', jasmine.any(Number)
-
 		it 'should set top', ->
 
 			@scope.clone = css: ->


### PR DESCRIPTION
This PR is raised for issue:

sticky-table-header mis aligns when the parent container is given some fixed width and not set to 100%. #39
